### PR TITLE
🎨 menuの位置を調整

### DIFF
--- a/src/components/domains/story/organisms/StoryTableRow/StoryTableRow.tsx
+++ b/src/components/domains/story/organisms/StoryTableRow/StoryTableRow.tsx
@@ -88,21 +88,7 @@ export const StoryTableRow: VFC<Props> = ({ story }) => {
       <TableCell align="right">
         <IconButton icon="MoreVert" width={24} onClick={(e) => handleClickMenu(e, story)} />
       </TableCell>
-      <Menu
-        onClick={(e) => e.stopPropagation()}
-        anchorEl={anchorEl}
-        open={open}
-        menuItems={menuItems}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-      />
+      <Menu onClick={(e) => e.stopPropagation()} anchorEl={anchorEl} open={open} menuItems={menuItems} onClose={handleClose} />
     </StyledTableRow>
   );
 };

--- a/src/components/parts/commons/organisms/Menu/Menu.tsx
+++ b/src/components/parts/commons/organisms/Menu/Menu.tsx
@@ -13,9 +13,17 @@ type Menu = {
 
 type Props = ComponentProps<typeof MuiMenu> & Menu;
 
-export const Menu: VFC<Props> = ({ menuItems, ...rest }) => {
+export const Menu: VFC<Props> = ({
+  menuItems,
+  anchorOrigin = { vertical: 'bottom', horizontal: 'right' },
+  transformOrigin = {
+    vertical: 'top',
+    horizontal: 'right',
+  },
+  ...rest
+}) => {
   return (
-    <MuiMenu {...rest}>
+    <MuiMenu anchorOrigin={anchorOrigin} transformOrigin={transformOrigin} {...rest}>
       {menuItems.map((menuItem, i) => (
         <MenuItem key={i} onClick={menuItem.onClick}>
           <ListItemIcon>{menuItem.icon}</ListItemIcon>


### PR DESCRIPTION
## 変更箇所
ストーリーリスト画面でのmenuの位置をボタンの右端に揃えました。

## 対象タスクのLink
https://app.clickup.com/t/1py8h69
