### PR TITLE
🐛 SideBarよりもNavigationBarが上に表示されるように修正

### DIFF
--- a/src/components/parts/layout/NavigationBar/NavigationBar.tsx
+++ b/src/components/parts/layout/NavigationBar/NavigationBar.tsx
@@ -75,6 +75,7 @@ export const Component: VFC<Props> = memo(({ currentUser, isValidating, onClickL
 });
 
 const StyledAppBar = styled(AppBar)`
+  position: relative;
   background-color: ${(props) => props.theme.palette.primary.main};
   padding: 12px 20px;
   align-items: center;


### PR DESCRIPTION
## 変更箇所
NavigationBarに  `position: relative;`を追加し、SideBarよりも上に表示されるように修正しました。

## 対象タスクのLink
https://app.clickup.com/t/1q9reuy
