### PR TITLE
🎨 apiを叩いてreactionを削除出来るように実装

### DIFF
--- a/src/components/domains/storyPost/DisplayStoryPostPaper/DisplayStoryPostPaper.tsx
+++ b/src/components/domains/storyPost/DisplayStoryPostPaper/DisplayStoryPostPaper.tsx
@@ -100,7 +100,14 @@ export const DisplayStoryPostPaper: VFC<Props> = ({
           return;
         }
 
-        if (SelectedEmojiId === emojiId) return;
+        if (SelectedEmojiId === emojiId) {
+          await restClient.apiDelete<Reaction>(`/reactions/${currentStoryPost.currentUserReaction._id}`);
+
+          setCurrentStoryPost({ ...currentStoryPost, currentUserReaction: undefined });
+
+          setSelectedEmojiId('');
+          return;
+        }
 
         const result = await restClient.apiPut<Reaction>(`/reactions/${currentStoryPost.currentUserReaction._id}`, {
           reaction: {

--- a/src/mocks/api/reaction.ts
+++ b/src/mocks/api/reaction.ts
@@ -14,3 +14,7 @@ export const postReaction = (req: any, res: any, ctx: any) => {
 export const putReaction = (req: any, res: any, ctx: any) => {
   return res(ctx.status(200));
 };
+
+export const deleteReaction = (req: any, res: any, ctx: any) => {
+  return res(ctx.status(200));
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,7 +3,7 @@ import { getAttachmentById } from './api/attachment';
 import { getCurrentUser } from './api/user';
 import { getStories, postStories } from './api/stories';
 import { getStoryPosts, postStoryPost, deleteStoryPost } from './api/storyPost';
-import { getReaction, postReaction, putReaction } from './api/reaction';
+import { getReaction, postReaction, putReaction, deleteReaction } from './api/reaction';
 
 const generateRoute = (path: string) => {
   return `${process.env.NEXT_PUBLIC_BACKEND_URL_FROM_CLIENT}/api/v1${path}`;
@@ -24,4 +24,5 @@ export const handlers = [
   rest.get(generateRoute('/reactions'), getReaction),
   rest.post(generateRoute('/reactions'), postReaction),
   rest.put(generateRoute('/reactions'), putReaction),
+  rest.delete(generateRoute('/reactions'), deleteReaction),
 ];


### PR DESCRIPTION
## 対象IssueのLink
close #327

## 変更箇所
絵文字を取り消す際にapiを叩いてreactionを削除するように実装しました。


