### PR TITLE
ストーリー詳細画面のOGPをOGPサーバーから表示できるようにする

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -11,4 +11,5 @@ export const URLS = {
     `/${productId}/story/${storyId}${storyPostId ? `?storyPostId=${storyPostId}` : ''}`,
   TERMS: '#',
   PRIVACY_POLICY: '#',
+  BUCKET_URL: 'https://storage.googleapis.com/proeco',
 };

--- a/src/pages/[productId]/story/[storyId].tsx
+++ b/src/pages/[productId]/story/[storyId].tsx
@@ -32,6 +32,7 @@ import { Breadcrumbs } from '~/components/parts/commons/Breadcrumbs';
 import { PaginationResult } from '~/interfaces';
 
 import { useErrorNotification } from '~/hooks/useErrorNotification';
+import { useSignedUrl } from '~/stores/attachment';
 
 type Props = {
   storyFromServerSide: Story;
@@ -41,6 +42,8 @@ type Props = {
 const StoryPage: ProecoNextPage<Props> = ({ storyFromServerSide, team }) => {
   const router = useRouter();
   const closeButtonRef = useRef<RewardElement>(null);
+
+  const { data: signedUrl } = useSignedUrl(team.iconImageId);
 
   const { notifyErrorMessage } = useErrorNotification();
 
@@ -121,7 +124,10 @@ const StoryPage: ProecoNextPage<Props> = ({ storyFromServerSide, team }) => {
 
   return (
     <>
-      <ProecoOgpHead title={story.title} />
+      <ProecoOgpHead
+        title={story.title}
+        image={`https://proeco-ogp.vercel.app/api/ogp?title=${story.title}&teamName=${team.name}&teamIconUrl=${signedUrl}`}
+      />
       <Box mx="auto" maxWidth="1200px">
         <Breadcrumbs breadcrumbsItems={[{ url: `${URLS.TEAMS(team.productId)}#story`, label: 'ストーリーリスト' }, { label: story.title }]} />
         <Box mt={1} mb={4} display="flex" alignItems="center" justifyContent="space-between">

--- a/src/pages/[productId]/story/[storyId].tsx
+++ b/src/pages/[productId]/story/[storyId].tsx
@@ -32,7 +32,8 @@ import { Breadcrumbs } from '~/components/parts/commons/Breadcrumbs';
 import { PaginationResult } from '~/interfaces';
 
 import { useErrorNotification } from '~/hooks/useErrorNotification';
-import { useSignedUrl } from '~/stores/attachment';
+import { useAttachment } from '~/stores/attachment';
+import { generateBucketUrl } from '~/utils/generateBucketUrl';
 
 type Props = {
   storyFromServerSide: Story;
@@ -43,7 +44,8 @@ const StoryPage: ProecoNextPage<Props> = ({ storyFromServerSide, team }) => {
   const router = useRouter();
   const closeButtonRef = useRef<RewardElement>(null);
 
-  const { data: signedUrl } = useSignedUrl(team.iconImageId);
+  const { data: teamIconAttachment } = useAttachment(team.iconImageId);
+  const teamIconUrl = generateBucketUrl(teamIconAttachment ? teamIconAttachment.filePath : '');
 
   const { notifyErrorMessage } = useErrorNotification();
 
@@ -126,7 +128,8 @@ const StoryPage: ProecoNextPage<Props> = ({ storyFromServerSide, team }) => {
     <>
       <ProecoOgpHead
         title={story.title}
-        image={`https://proeco-ogp.vercel.app/api/ogp?title=${story.title}&teamName=${team.name}&teamIconUrl=${signedUrl}`}
+        image={`https://proeco-ogp.vercel.app/api/ogp?title=${story.title}&teamName=${team.name}&teamIconUrl=${teamIconUrl}`}
+        url={`${process.env.NEXT_PUBLIC_ROOT_URL}/${team.productId}/story/${story._id}`}
       />
       <Box mx="auto" maxWidth="1200px">
         <Breadcrumbs breadcrumbsItems={[{ url: `${URLS.TEAMS(team.productId)}#story`, label: 'ストーリーリスト' }, { label: story.title }]} />

--- a/src/pages/[productId]/story/[storyId].tsx
+++ b/src/pages/[productId]/story/[storyId].tsx
@@ -25,27 +25,26 @@ import { CreateNewStoryPostPaper } from '~/components/domains/storyPost/CreateNe
 import { Dropdown } from '~/components/parts/commons/Dropdown';
 import { UserIcon } from '~/components/domains/user/UserIcon';
 import { DisplayStoryPostPaper } from '~/components/domains/storyPost/DisplayStoryPostPaper';
-import { Reaction, StoryPost, Team } from '~/domains';
+import { Attachment, Reaction, StoryPost, Team } from '~/domains';
 import { UpdateStoryModal } from '~/components/domains/story/UpdateStoryModal';
 import { DeleteStoryModal } from '~/components/domains/story/DeleteStoryModal';
 import { Breadcrumbs } from '~/components/parts/commons/Breadcrumbs';
 import { PaginationResult } from '~/interfaces';
 
 import { useErrorNotification } from '~/hooks/useErrorNotification';
-import { useAttachment } from '~/stores/attachment';
 import { generateBucketUrl } from '~/utils/generateBucketUrl';
 
 type Props = {
   storyFromServerSide: Story;
   team: Team;
+  teamIconAttachment: Attachment;
 };
 
-const StoryPage: ProecoNextPage<Props> = ({ storyFromServerSide, team }) => {
+const StoryPage: ProecoNextPage<Props> = ({ storyFromServerSide, team, teamIconAttachment }) => {
   const router = useRouter();
   const closeButtonRef = useRef<RewardElement>(null);
 
-  const { data: teamIconAttachment } = useAttachment(team.iconImageId);
-  const teamIconUrl = generateBucketUrl(teamIconAttachment ? teamIconAttachment.filePath : '');
+  const teamIconUrl = generateBucketUrl(teamIconAttachment.filePath);
 
   const { notifyErrorMessage } = useErrorNotification();
 
@@ -238,7 +237,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     const { data: story } = await restClient.apiGet(`/stories/${storyId}`);
 
-    if (!team || !story) {
+    const { data: teamIconAttachment } = await restClient.apiGet(`/attachments/${team.iconImageId}`);
+
+    if (!team || !story || !teamIconAttachment) {
       return {
         redirect: {
           permanent: false,
@@ -247,7 +248,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       };
     }
 
-    return { props: { storyFromServerSide: story, team } };
+    return { props: { storyFromServerSide: story, team, teamIconAttachment } };
   } catch (error) {
     return {
       redirect: {

--- a/src/stores/attachment/index.ts
+++ b/src/stores/attachment/index.ts
@@ -1,1 +1,2 @@
+export { useAttachment } from './useAttachment';
 export { useSignedUrl } from './useSignedUrl';

--- a/src/stores/attachment/useAttachment.ts
+++ b/src/stores/attachment/useAttachment.ts
@@ -1,0 +1,21 @@
+import { SWRResponse } from 'swr';
+import useImmutableSWR from 'swr/immutable';
+
+import { restClient } from '~/utils/rest-client';
+import { Attachment, convertAttachmentFromServer } from '~/domains';
+
+/**
+ * Attachmentを取得するSWR
+ * @params attachmentId 取得対象のファイルID
+ * @returns data Attachment
+ * @returns isValidating 取得中を表す boolean
+ * @returns error エラー
+ * @returns mutate データの更新関数
+ */
+export const useAttachment = (attachmentId?: Attachment['_id']): SWRResponse<Attachment, Error> => {
+  const key = attachmentId ? `/attachments/${attachmentId}` : null;
+
+  return useImmutableSWR(key, (endpoint: string) =>
+    restClient.apiGet<Attachment>(endpoint).then((result) => convertAttachmentFromServer(result.data)),
+  );
+};

--- a/src/utils/generateBucketUrl/generateBucketUrl.ts
+++ b/src/utils/generateBucketUrl/generateBucketUrl.ts
@@ -1,0 +1,10 @@
+const BUCKET_URL = 'https://storage.googleapis.com/proeco/';
+
+/**
+ * filePathからBucketUrlを生成する
+ * @param {string} filePath
+ * @returns string
+ */
+export const generateBucketUrl = (filePath: string) => {
+  return `${BUCKET_URL}/${filePath}`;
+};

--- a/src/utils/generateBucketUrl/generateBucketUrl.ts
+++ b/src/utils/generateBucketUrl/generateBucketUrl.ts
@@ -1,4 +1,4 @@
-const BUCKET_URL = 'https://storage.googleapis.com/proeco/';
+import { URLS } from '~/constants/urls';
 
 /**
  * filePathからBucketUrlを生成する
@@ -6,5 +6,5 @@ const BUCKET_URL = 'https://storage.googleapis.com/proeco/';
  * @returns string
  */
 export const generateBucketUrl = (filePath: string) => {
-  return `${BUCKET_URL}/${filePath}`;
+  return `${URLS.BUCKET_URL}/${filePath}`;
 };

--- a/src/utils/generateBucketUrl/index.ts
+++ b/src/utils/generateBucketUrl/index.ts
@@ -1,0 +1,1 @@
+export { generateBucketUrl } from './generateBucketUrl';


### PR DESCRIPTION
## 対象IssueのLink
close #413 

## 変更箇所

- idからattachmentを取得するuseAttachmentを作成
- utilsにアクセス用のurl を生成するgenerateBucketUrl を作成
- それらを使用し、ストーリー詳細画面のOGPを設定
