### PR TITLE
🐛 UserIcon のリンクの範囲を修正

### DIFF
--- a/src/components/parts/commons/TimeLineItem/TimeLineItem.tsx
+++ b/src/components/parts/commons/TimeLineItem/TimeLineItem.tsx
@@ -46,6 +46,9 @@ const StyledTimeLineDot = styled(TimelineDot)`
   padding: 0;
   margin: 0;
   border: none;
+  .MuiTypography-root {
+    height: fit-content;
+  }
 `;
 
 const StyledTimeLineConnector = styled(TimelineConnector)`


### PR DESCRIPTION
## 対象IssueのLink
close #458

## 変更箇所
TimeLineItemのUserIconのリンクの範囲が下に伸びているのを、ピッタリになるように修正しました
