### PR TITLE
ユーザーページにユーザーの情報を表示

### DIFF
--- a/src/pages/user/[userId].tsx
+++ b/src/pages/user/[userId].tsx
@@ -3,9 +3,10 @@ import { ReactNode } from 'react';
 import { GetServerSideProps } from 'next';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
+import { Typography } from '~/components/parts/commons';
+import { UserIcon } from '~/components/domains/user/UserIcon';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
 import { User } from '~/domains';
-import { UserIcon } from '~/components/domains/user/UserIcon';
 import { restClient } from '~/utils/rest-client';
 
 type Props = {
@@ -17,8 +18,14 @@ const Dashboard: ProecoNextPage<Props> = ({ user }) => {
     <>
       <ProecoOgpHead />
       <Box mx="auto" maxWidth="1200px">
-        <Box>
-          <UserIcon attachmentId={user.iconImageId} size={60} userId={user._id} />
+        <Box display="flex" alignItems="flex-start" gap="16px">
+          <UserIcon attachmentId={user.iconImageId} size={120} userId={user._id} />
+          <Box pt="8px">
+            <Typography variant="h3" marginBottom="16px" bold>
+              {user.name}
+            </Typography>
+            <Typography>{user.description}</Typography>
+          </Box>
         </Box>
       </Box>
     </>

--- a/src/pages/user/[userId].tsx
+++ b/src/pages/user/[userId].tsx
@@ -1,24 +1,30 @@
-import { Box } from '@mui/system';
-import { ReactNode } from 'react';
 import { GetServerSideProps } from 'next';
+import { ReactNode } from 'react';
+import { Box } from '@mui/system';
+import { Grid } from '@mui/material';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
-import { Typography } from '~/components/parts/commons';
+import { Link, Typography } from '~/components/parts/commons';
 import { UserIcon } from '~/components/domains/user/UserIcon';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
 import { User } from '~/domains';
 import { restClient } from '~/utils/rest-client';
+import { useTeamsRelatedUser } from '~/stores/team';
+import { SkeltonTeamCard, TeamCard } from '~/components/domains/team/TeamCard/TeamCard';
+import { URLS } from '~/constants';
 
 type Props = {
   user: User;
 };
 
 const Dashboard: ProecoNextPage<Props> = ({ user }) => {
+  const { data: teamsRelatedUser } = useTeamsRelatedUser({ userId: user._id });
+
   return (
     <>
       <ProecoOgpHead />
       <Box mx="auto" maxWidth="1200px">
-        <Box display="flex" alignItems="flex-start" gap="16px">
+        <Box display="flex" alignItems="flex-start" gap="16px" mb="48px">
           <UserIcon attachmentId={user.iconImageId} size={120} userId={user._id} />
           <Box pt="8px">
             <Typography variant="h3" marginBottom="16px" bold>
@@ -27,6 +33,35 @@ const Dashboard: ProecoNextPage<Props> = ({ user }) => {
             <Typography>{user.description}</Typography>
           </Box>
         </Box>
+        <Typography variant="h4" bold textAlign="center" mb="20px">
+          所属チームリスト
+        </Typography>
+        <Grid container maxWidth="900px" mx="auto">
+          {teamsRelatedUser ? (
+            teamsRelatedUser.map((team) => (
+              <Grid item key={`top-${team._id}`} xs={12} sm={6} px={1} pb={2}>
+                <Link href={URLS.TEAMS(team.productId)}>
+                  <TeamCard
+                    name={team.name}
+                    productId={team.productId}
+                    description={team.description}
+                    attachmentId={team.iconImageId}
+                    url={team.url}
+                  />
+                </Link>
+              </Grid>
+            ))
+          ) : (
+            <>
+              <Grid item xs={12} sm={6} px={1}>
+                <SkeltonTeamCard />
+              </Grid>
+              <Grid item xs={12} sm={6} px={1}>
+                <SkeltonTeamCard />
+              </Grid>
+            </>
+          )}
+        </Grid>
       </Box>
     </>
   );

--- a/src/pages/user/[userId].tsx
+++ b/src/pages/user/[userId].tsx
@@ -1,10 +1,10 @@
 import { GetServerSideProps } from 'next';
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { Box } from '@mui/system';
 import { Grid } from '@mui/material';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
-import { Link, Typography } from '~/components/parts/commons';
+import { Icon, Link, Typography } from '~/components/parts/commons';
 import { UserIcon } from '~/components/domains/user/UserIcon';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
 import { User } from '~/domains';
@@ -20,6 +20,42 @@ type Props = {
 const Dashboard: ProecoNextPage<Props> = ({ user }) => {
   const { data: teamsRelatedUser } = useTeamsRelatedUser({ userId: user._id });
 
+  const teamsContent = useMemo(() => {
+    if (!teamsRelatedUser) {
+      return (
+        <>
+          <Grid item xs={12} sm={6} px={1}>
+            <SkeltonTeamCard />
+          </Grid>
+          <Grid item xs={12} sm={6} px={1}>
+            <SkeltonTeamCard />
+          </Grid>
+        </>
+      );
+    }
+
+    if (teamsRelatedUser.length === 0)
+      return (
+        <Grid item xs={24} textAlign="center" pt="20px">
+          <Typography variant="h3">所属しているチームがありません</Typography>
+        </Grid>
+      );
+
+    return teamsRelatedUser.map((team) => (
+      <Grid item key={`top-${team._id}`} xs={12} sm={6} px={1} pb={2}>
+        <Link href={URLS.TEAMS(team.productId)}>
+          <TeamCard
+            name={team.name}
+            productId={team.productId}
+            description={team.description}
+            attachmentId={team.iconImageId}
+            url={team.url}
+          />
+        </Link>
+      </Grid>
+    ));
+  }, [teamsRelatedUser]);
+
   return (
     <>
       <ProecoOgpHead />
@@ -33,34 +69,12 @@ const Dashboard: ProecoNextPage<Props> = ({ user }) => {
             <Typography>{user.description}</Typography>
           </Box>
         </Box>
-        <Typography variant="h4" bold textAlign="center" mb="20px">
-          所属チームリスト
+        <Typography variant="h4" bold display="flex" alignItems="center" gap="8px" mb="20px">
+          <Icon icon="Group" width={32} />
+          チームリスト
         </Typography>
         <Grid container maxWidth="900px" mx="auto">
-          {teamsRelatedUser ? (
-            teamsRelatedUser.map((team) => (
-              <Grid item key={`top-${team._id}`} xs={12} sm={6} px={1} pb={2}>
-                <Link href={URLS.TEAMS(team.productId)}>
-                  <TeamCard
-                    name={team.name}
-                    productId={team.productId}
-                    description={team.description}
-                    attachmentId={team.iconImageId}
-                    url={team.url}
-                  />
-                </Link>
-              </Grid>
-            ))
-          ) : (
-            <>
-              <Grid item xs={12} sm={6} px={1}>
-                <SkeltonTeamCard />
-              </Grid>
-              <Grid item xs={12} sm={6} px={1}>
-                <SkeltonTeamCard />
-              </Grid>
-            </>
-          )}
+          {teamsContent}
         </Grid>
       </Box>
     </>

--- a/src/pages/user/[userId].tsx
+++ b/src/pages/user/[userId].tsx
@@ -1,24 +1,49 @@
 import { Box } from '@mui/system';
 import { ReactNode } from 'react';
-import { Typography } from '~/components/parts/commons';
+import { GetServerSideProps } from 'next';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
+import { User } from '~/domains';
+import { UserIcon } from '~/components/domains/user/UserIcon';
+import { restClient } from '~/utils/rest-client';
 
-const Dashboard: ProecoNextPage = () => {
+type Props = {
+  user: User;
+};
+
+const Dashboard: ProecoNextPage<Props> = ({ user }) => {
   return (
     <>
       <ProecoOgpHead />
       <Box mx="auto" maxWidth="1200px">
-        <Box mb={2} display="flex" alignItems="center" justifyContent="space-between">
-          <Typography variant="h3" bold>
-            ユーザーページ
-          </Typography>
+        <Box>
+          <UserIcon attachmentId={user.iconImageId} size={60} userId={user._id} />
         </Box>
-        TBD
       </Box>
     </>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { userId } = context.query;
+
+  try {
+    const { data: user } = await restClient.apiGet<User>(`/users/${userId}`);
+
+    if (!user) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: '/404',
+        },
+      };
+    }
+
+    return { props: { user } };
+  } catch (error) {
+    return { props: {} };
+  }
 };
 
 Dashboard.getLayout = (page: ReactNode) => <DashboardLayout>{page}</DashboardLayout>;


### PR DESCRIPTION
## 対象IssueのLink
close #449

## 変更箇所
ユーザーページに、UserのIcon、name、自己紹介、所属しているチーム一覧を表示するように実装しました。