### PR TITLE
🐛 loading中のSkeltonStoryCardの表示を修正

### DIFF
--- a/src/components/domains/story/StoryTab/StoryTab.tsx
+++ b/src/components/domains/story/StoryTab/StoryTab.tsx
@@ -74,20 +74,22 @@ export const StoryTab: VFC<Props> = ({ team, editable }) => {
       )}
       <Box mb={5}>
         <StyledCarousel responsive={responsive} showDots arrows={false}>
-          {openStoryList ? (
-            openStoryList.docs.map((story) => {
-              return (
-                <Box px={2} key={`top-${story._id}`}>
-                  <StoryCard story={story} isLink />
-                </Box>
-              );
-            })
-          ) : (
-            <>
-              <SkeltonStoryCard />
-              <SkeltonStoryCard />
-            </>
-          )}
+          {openStoryList
+            ? openStoryList.docs.map((story) => {
+                return (
+                  <Box px={2} key={`top-${story._id}`}>
+                    <StoryCard story={story} isLink />
+                  </Box>
+                );
+              })
+            : [
+                <Box px={2} key="first">
+                  <SkeltonStoryCard />
+                </Box>,
+                <Box px={2} key="second">
+                  <SkeltonStoryCard />
+                </Box>,
+              ]}
         </StyledCarousel>
       </Box>
       {closeStoriesPagination && closeStoriesPagination.docs.length !== 0 && (


### PR DESCRIPTION
## 対象IssueのLink
close #485

## 変更箇所
loading中のSkeltonStoryCardの表示が縦にくっついて並んでいたのを、横に隙間をあけて並ぶように修正しました


