### PR TITLE
StoryCardとTeamCardの画像をCardのimagePathを渡して表示するように修正

### DIFF
--- a/src/components/domains/story/StoryCard/StoryCard.tsx
+++ b/src/components/domains/story/StoryCard/StoryCard.tsx
@@ -4,7 +4,7 @@ import { Box, Skeleton } from '@mui/material';
 import styled from 'styled-components';
 
 import { Story } from '~/domains';
-import { Card, Emoji, Link } from '~/components/parts/commons';
+import { Card, Emoji, FixedImage, Link, SkeltonFixedImage } from '~/components/parts/commons';
 import { useTeam } from '~/stores/team';
 import { TeamIcon, SkeltonTeamIcon, GuestTeamIcon } from '~/components/domains/team/TeamIcon';
 import { formatDistanceToNow } from '~/utils/formatDistanceToNow';
@@ -18,10 +18,7 @@ type Props = {
 
 export const SkeltonStoryCard: VFC = () => {
   return (
-    <StyledStoryCard>
-      <StyledDiv className="position-relative w-100">
-        <StyledSkeleton className="position-absolute" variant="rectangular" />
-      </StyledDiv>
+    <StyledStoryCard headerContent={<SkeltonFixedImage />}>
       <Skeleton variant="text" width="50px" />
       <Skeleton variant="text" width="100%" />
       <Box mt="12px" display="flex" alignItems="center" gap="8px">
@@ -37,14 +34,14 @@ export const StoryCard: VFC<Props> = ({ story }) => {
   const { data: teamIconAttachment } = useAttachment(team?.iconImageId);
 
   const ogpUrl = useMemo(
-    () => (team && teamIconAttachment ? createOgpUrl(story.title, team.name, teamIconAttachment.filePath) : ''),
+    () => team && teamIconAttachment && createOgpUrl(story.title, team.name, teamIconAttachment.filePath),
     [story, team, teamIconAttachment],
   );
   const displayDate = formatDistanceToNow(story.updatedAt);
 
   const StoryCardContent = useMemo(() => {
     return (
-      <StyledStoryCard imagePath={ogpUrl}>
+      <StyledStoryCard headerContent={ogpUrl ? <FixedImage imageUrl={ogpUrl} /> : <SkeltonFixedImage />}>
         <time className="text-light fs-4" dateTime={story.updatedAt.toLocaleDateString()}>
           {displayDate}
         </time>
@@ -75,18 +72,6 @@ export const StoryCard: VFC<Props> = ({ story }) => {
 
   return <Link href={URLS.TEAMS_STORY(team.productId, story._id)}>{StoryCardContent}</Link>;
 };
-
-const StyledDiv = styled.div`
-  padding-top: 52.5%;
-`;
-
-const StyledSkeleton = styled(Skeleton)`
-  object-fit: cover;
-  top: -16px;
-  left: -16px;
-  width: calc(100% + 32px);
-  height: calc(100% + 16px);
-`;
 
 const StyledStoryCard = styled(Card)`
   box-sizing: border-box;

--- a/src/components/domains/story/StoryCard/StoryCard.tsx
+++ b/src/components/domains/story/StoryCard/StoryCard.tsx
@@ -18,14 +18,14 @@ type Props = {
 
 export const SkeltonStoryCard: VFC = () => {
   return (
-    <StyledStoryCard headerContent={<SkeltonFixedImage />}>
+    <StyledCard headerContent={<SkeltonFixedImage />}>
       <Skeleton variant="text" width="50px" />
       <Skeleton variant="text" width="100%" />
       <Box mt="12px" display="flex" alignItems="center" gap="8px">
         <SkeltonTeamIcon size={32} />
         <Skeleton variant="text" width="100px" />
       </Box>
-    </StyledStoryCard>
+    </StyledCard>
   );
 };
 
@@ -41,7 +41,7 @@ export const StoryCard: VFC<Props> = ({ story }) => {
 
   const StoryCardContent = useMemo(() => {
     return (
-      <StyledStoryCard headerContent={ogpUrl ? <FixedImage imageUrl={ogpUrl} /> : <SkeltonFixedImage />}>
+      <StyledCard headerContent={ogpUrl ? <FixedImage imageUrl={ogpUrl} /> : <SkeltonFixedImage />}>
         <time className="text-light fs-4" dateTime={story.updatedAt.toLocaleDateString()}>
           {displayDate}
         </time>
@@ -64,7 +64,7 @@ export const StoryCard: VFC<Props> = ({ story }) => {
             </>
           )}
         </Box>
-      </StyledStoryCard>
+      </StyledCard>
     );
   }, [displayDate, story, team, ogpUrl]);
 
@@ -73,7 +73,7 @@ export const StoryCard: VFC<Props> = ({ story }) => {
   return <Link href={URLS.TEAMS_STORY(team.productId, story._id)}>{StoryCardContent}</Link>;
 };
 
-const StyledStoryCard = styled(Card)`
+const StyledCard = styled(Card)`
   box-sizing: border-box;
   position: relative;
   width: 100%;

--- a/src/components/domains/story/StoryCard/StoryCard.tsx
+++ b/src/components/domains/story/StoryCard/StoryCard.tsx
@@ -10,6 +10,7 @@ import { TeamIcon, SkeltonTeamIcon, GuestTeamIcon } from '~/components/domains/t
 import { formatDistanceToNow } from '~/utils/formatDistanceToNow';
 import { URLS } from '~/constants';
 import { useAttachment } from '~/stores/attachment';
+import { createOgpUrl } from '~/utils/createOgpUrl/createOgpUrl';
 
 type Props = {
   story: Story;
@@ -36,10 +37,7 @@ export const StoryCard: VFC<Props> = ({ story }) => {
   const { data: teamIconAttachment } = useAttachment(team?.iconImageId);
 
   const ogpUrl = useMemo(
-    () =>
-      team && teamIconAttachment
-        ? `https://proeco-ogp.vercel.app/api/ogp?title=${story.title}&teamName=${team.name}&teamIconUrl=${teamIconAttachment.filePath}`
-        : '',
+    () => (team && teamIconAttachment ? createOgpUrl(story.title, team.name, teamIconAttachment.filePath) : ''),
     [story, team, teamIconAttachment],
   );
   const displayDate = formatDistanceToNow(story.updatedAt);
@@ -52,7 +50,7 @@ export const StoryCard: VFC<Props> = ({ story }) => {
         </time>
         <div className="d-flex align-items-center">
           <span className="me-1">
-            <Emoji emojiId={story.emojiId} size={16} />
+            <Emoji emojiId={story.emojiId} size={20} />
           </span>
           <p className="fw-bold mb-0">{story.title}</p>
         </div>

--- a/src/components/domains/story/StoryCard/StoryCard.tsx
+++ b/src/components/domains/story/StoryCard/StoryCard.tsx
@@ -1,12 +1,14 @@
 import React, { VFC, useMemo } from 'react';
 import { Box, Skeleton } from '@mui/material';
-import { styled } from '@mui/material/styles';
+
+import styled from 'styled-components';
+
 import { Story } from '~/domains';
-import { Card, Link } from '~/components/parts/commons';
+import { Card, Emoji, Link } from '~/components/parts/commons';
 import { useTeam } from '~/stores/team';
 import { TeamIcon, SkeltonTeamIcon, GuestTeamIcon } from '~/components/domains/team/TeamIcon';
 import { formatDistanceToNow } from '~/utils/formatDistanceToNow';
-import { IMAGE_PATH, URLS } from '~/constants';
+import { URLS } from '~/constants';
 import { useAttachment } from '~/stores/attachment';
 
 type Props = {
@@ -15,7 +17,10 @@ type Props = {
 
 export const SkeltonStoryCard: VFC = () => {
   return (
-    <StyledStoryCard imagePath={IMAGE_PATH.NO_IMAGE}>
+    <StyledStoryCard>
+      <StyledDiv className="position-relative w-100">
+        <StyledSkeleton className="position-absolute" variant="rectangular" />
+      </StyledDiv>
       <Skeleton variant="text" width="50px" />
       <Skeleton variant="text" width="100%" />
       <Box mt="12px" display="flex" alignItems="center" gap="8px">
@@ -42,8 +47,15 @@ export const StoryCard: VFC<Props> = ({ story }) => {
   const StoryCardContent = useMemo(() => {
     return (
       <StyledStoryCard imagePath={ogpUrl}>
-        <StyledTime dateTime={story.updatedAt.toLocaleDateString()}>{displayDate}</StyledTime>
-        <p className="fw-bold mb-0">{story.title}</p>
+        <time className="text-light fs-4" dateTime={story.updatedAt.toLocaleDateString()}>
+          {displayDate}
+        </time>
+        <div className="d-flex align-items-center">
+          <span className="me-1">
+            <Emoji emojiId={story.emojiId} size={16} />
+          </span>
+          <p className="fw-bold mb-0">{story.title}</p>
+        </div>
         <Box mt="12px" display="flex" alignItems="center" gap="8px">
           {team ? (
             <>
@@ -66,15 +78,22 @@ export const StoryCard: VFC<Props> = ({ story }) => {
   return <Link href={URLS.TEAMS_STORY(team.productId, story._id)}>{StoryCardContent}</Link>;
 };
 
+const StyledDiv = styled.div`
+  padding-top: 52.5%;
+`;
+
+const StyledSkeleton = styled(Skeleton)`
+  object-fit: cover;
+  top: -16px;
+  left: -16px;
+  width: calc(100% + 32px);
+  height: calc(100% + 16px);
+`;
+
 const StyledStoryCard = styled(Card)`
   box-sizing: border-box;
   position: relative;
   width: 100%;
   top: 0;
   transition: all 0.3s;
-`;
-
-const StyledTime = styled('time')`
-  font-size: 10px;
-  color: ${(props) => props.theme.palette.textColor.light};
 `;

--- a/src/components/domains/story/StoryCard/StoryCard.tsx
+++ b/src/components/domains/story/StoryCard/StoryCard.tsx
@@ -16,7 +16,6 @@ type Props = {
 export const SkeltonStoryCard: VFC = () => {
   return (
     <StyledStoryCard imagePath={IMAGE_PATH.NO_IMAGE}>
-      <Box width="100%" bgcolor="#ced7fd" pt="40%" position="relative"></Box>
       <Skeleton variant="text" width="50px" />
       <Skeleton variant="text" width="100%" />
       <Box mt="12px" display="flex" alignItems="center" gap="8px">

--- a/src/components/domains/team/TeamCard/TeamCard.stories.tsx
+++ b/src/components/domains/team/TeamCard/TeamCard.stories.tsx
@@ -23,6 +23,7 @@ DefaultTeamCard.args = {
   name: 'Proeco',
   description: 'description',
   attachmentId: 'attachmentId1',
+  url: 'https://www.proeco.app/',
 };
 
 export const LongTextTeamCard = Template.bind({});

--- a/src/components/domains/team/TeamCard/TeamCard.tsx
+++ b/src/components/domains/team/TeamCard/TeamCard.tsx
@@ -4,7 +4,7 @@ import { Box, styled } from '@mui/system';
 import { TeamIcon } from '~/components/domains/team/TeamIcon';
 import { Card } from '~/components/parts/commons';
 import { useOgp } from '~/stores/ogp';
-import { FixedImage } from '~/components/parts/commons/FixedImage';
+import { IMAGE_PATH } from '~/constants';
 
 type Props = {
   name: string;
@@ -16,8 +16,7 @@ type Props = {
 
 export const SkeltonTeamCard: VFC = () => {
   return (
-    <StyledTeamCard>
-      <FixedImage />
+    <StyledTeamCard imagePath={IMAGE_PATH.NO_IMAGE}>
       <Box p={2}>
         <Box display="flex" alignItems="center" p={2}>
           <Box mr="8px">
@@ -38,9 +37,8 @@ export const TeamCard: VFC<Props> = ({ name, productId, description, attachmentI
   const { data: ogp } = useOgp(url);
 
   return (
-    <StyledTeamCard>
-      <FixedImage imageUrl={ogp?.image} />
-      <Box position="relative" p={2}>
+    <StyledTeamCard imagePath={ogp?.image || IMAGE_PATH.NO_IMAGE}>
+      <Box>
         <Box position="absolute" top={-25} display="flex" gap={1} alignItems="end" mb="8px">
           <TeamIcon size={50} attachmentId={attachmentId} />
           <span className="fw-bold maximum_lines_1">{name}</span>

--- a/src/components/domains/team/TeamCard/TeamCard.tsx
+++ b/src/components/domains/team/TeamCard/TeamCard.tsx
@@ -3,9 +3,8 @@ import { Skeleton } from '@mui/material';
 import { Box } from '@mui/system';
 import styled from 'styled-components';
 import { TeamIcon } from '~/components/domains/team/TeamIcon';
-import { Card } from '~/components/parts/commons';
+import { Card, FixedImage, SkeltonFixedImage } from '~/components/parts/commons';
 import { useOgp } from '~/stores/ogp';
-import { IMAGE_PATH } from '~/constants';
 
 type Props = {
   name: string;
@@ -17,10 +16,7 @@ type Props = {
 
 export const SkeltonTeamCard: VFC = () => {
   return (
-    <StyledTeamCard>
-      <StyledDiv className="position-relative w-100">
-        <StyledSkeleton className="position-absolute" variant="rectangular" />
-      </StyledDiv>
+    <StyledTeamCard headerContent={<SkeltonFixedImage />}>
       <Box display="flex" alignItems="center" p={2}>
         <Box mr="8px">
           <Skeleton variant="circular" width={40} height={40} />
@@ -39,7 +35,7 @@ export const TeamCard: VFC<Props> = ({ name, productId, description, attachmentI
   const { data: ogp } = useOgp(url);
 
   return (
-    <StyledTeamCard imagePath={ogp?.image || IMAGE_PATH.NO_IMAGE}>
+    <StyledTeamCard headerContent={ogp ? <FixedImage imageUrl={ogp?.image} /> : <SkeltonFixedImage />}>
       <Box position="absolute" top={-25} display="flex" gap={1} alignItems="end" mb="8px">
         <TeamIcon size={50} attachmentId={attachmentId} />
         <span className="fw-bold maximum_lines_1">{name}</span>
@@ -49,18 +45,6 @@ export const TeamCard: VFC<Props> = ({ name, productId, description, attachmentI
     </StyledTeamCard>
   );
 };
-
-const StyledDiv = styled.div`
-  padding-top: 52.5%;
-`;
-
-const StyledSkeleton = styled(Skeleton)`
-  object-fit: cover;
-  top: -16px;
-  left: -16px;
-  width: calc(100% + 32px);
-  height: calc(100% + 16px);
-`;
 
 const StyledTeamCard = styled(Card)`
   box-sizing: border-box;

--- a/src/components/domains/team/TeamCard/TeamCard.tsx
+++ b/src/components/domains/team/TeamCard/TeamCard.tsx
@@ -17,17 +17,15 @@ type Props = {
 export const SkeltonTeamCard: VFC = () => {
   return (
     <StyledTeamCard imagePath={IMAGE_PATH.NO_IMAGE}>
-      <Box p={2}>
-        <Box display="flex" alignItems="center" p={2}>
-          <Box mr="8px">
-            <Skeleton variant="circular" width={40} height={40} />
-          </Box>
-          <Skeleton variant="text" width="100%" />
+      <Box display="flex" alignItems="center" p={2}>
+        <Box mr="8px">
+          <Skeleton variant="circular" width={40} height={40} />
         </Box>
-        <Box>
-          <Skeleton variant="text" width="100%" />
-          <Skeleton variant="text" width="100%" />
-        </Box>
+        <Skeleton variant="text" width="100%" />
+      </Box>
+      <Box>
+        <Skeleton variant="text" width="100%" />
+        <Skeleton variant="text" width="100%" />
       </Box>
     </StyledTeamCard>
   );
@@ -38,14 +36,12 @@ export const TeamCard: VFC<Props> = ({ name, productId, description, attachmentI
 
   return (
     <StyledTeamCard imagePath={ogp?.image || IMAGE_PATH.NO_IMAGE}>
-      <Box>
-        <Box position="absolute" top={-25} display="flex" gap={1} alignItems="end" mb="8px">
-          <TeamIcon size={50} attachmentId={attachmentId} />
-          <span className="fw-bold maximum_lines_1">{name}</span>
-          <span className="text-light fs-3 maximum_lines_1">@{productId}</span>
-        </Box>
-        <span className="mt-3 fs-3 maximum_lines_2">{description}</span>
+      <Box position="absolute" top={-25} display="flex" gap={1} alignItems="end" mb="8px">
+        <TeamIcon size={50} attachmentId={attachmentId} />
+        <span className="fw-bold maximum_lines_1">{name}</span>
+        <span className="text-light fs-3 maximum_lines_1">@{productId}</span>
       </Box>
+      <span className="mt-3 fs-3 maximum_lines_2">{description}</span>
     </StyledTeamCard>
   );
 };

--- a/src/components/domains/team/TeamCard/TeamCard.tsx
+++ b/src/components/domains/team/TeamCard/TeamCard.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const SkeltonTeamCard: VFC = () => {
   return (
-    <StyledTeamCard headerContent={<SkeltonFixedImage />}>
+    <StyledCard headerContent={<SkeltonFixedImage />}>
       <Box display="flex" alignItems="center" p={2}>
         <Box mr="8px">
           <Skeleton variant="circular" width={40} height={40} />
@@ -27,7 +27,7 @@ export const SkeltonTeamCard: VFC = () => {
         <Skeleton variant="text" width="100%" />
         <Skeleton variant="text" width="100%" />
       </Box>
-    </StyledTeamCard>
+    </StyledCard>
   );
 };
 
@@ -35,18 +35,18 @@ export const TeamCard: VFC<Props> = ({ name, productId, description, attachmentI
   const { data: ogp } = useOgp(url);
 
   return (
-    <StyledTeamCard headerContent={ogp ? <FixedImage imageUrl={ogp?.image} /> : <SkeltonFixedImage />}>
+    <StyledCard headerContent={ogp ? <FixedImage imageUrl={ogp?.image} /> : <SkeltonFixedImage />}>
       <Box position="absolute" top={-25} display="flex" gap={1} alignItems="end" mb="8px">
         <TeamIcon size={50} attachmentId={attachmentId} />
         <span className="fw-bold maximum_lines_1">{name}</span>
         <span className="text-light fs-3 maximum_lines_1">@{productId}</span>
       </Box>
       <span className="mt-3 fs-3 maximum_lines_2">{description}</span>
-    </StyledTeamCard>
+    </StyledCard>
   );
 };
 
-const StyledTeamCard = styled(Card)`
+const StyledCard = styled(Card)`
   box-sizing: border-box;
   position: relative;
   top: 0;

--- a/src/components/domains/team/TeamCard/TeamCard.tsx
+++ b/src/components/domains/team/TeamCard/TeamCard.tsx
@@ -1,6 +1,7 @@
 import React, { VFC } from 'react';
 import { Skeleton } from '@mui/material';
-import { Box, styled } from '@mui/system';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
 import { TeamIcon } from '~/components/domains/team/TeamIcon';
 import { Card } from '~/components/parts/commons';
 import { useOgp } from '~/stores/ogp';
@@ -16,7 +17,10 @@ type Props = {
 
 export const SkeltonTeamCard: VFC = () => {
   return (
-    <StyledTeamCard imagePath={IMAGE_PATH.NO_IMAGE}>
+    <StyledTeamCard>
+      <StyledDiv className="position-relative w-100">
+        <StyledSkeleton className="position-absolute" variant="rectangular" />
+      </StyledDiv>
       <Box display="flex" alignItems="center" p={2}>
         <Box mr="8px">
           <Skeleton variant="circular" width={40} height={40} />
@@ -45,6 +49,18 @@ export const TeamCard: VFC<Props> = ({ name, productId, description, attachmentI
     </StyledTeamCard>
   );
 };
+
+const StyledDiv = styled.div`
+  padding-top: 52.5%;
+`;
+
+const StyledSkeleton = styled(Skeleton)`
+  object-fit: cover;
+  top: -16px;
+  left: -16px;
+  width: calc(100% + 32px);
+  height: calc(100% + 16px);
+`;
 
 const StyledTeamCard = styled(Card)`
   box-sizing: border-box;

--- a/src/components/parts/commons/Card/Card.stories.tsx
+++ b/src/components/parts/commons/Card/Card.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Box } from '@mui/system';
 
-import { Card } from '~/components/parts/commons';
+import { Card, FixedImage } from '~/components/parts/commons';
 
 export default {
   title: 'parts/commons/Card',
@@ -24,5 +24,5 @@ export const DefaultCard = Template.bind({});
 
 export const CardWithImage = Template.bind({});
 CardWithImage.args = {
-  imagePath: 'https://itizawa-tech.growi.cloud/attachment/61bb543444194e2b1d023552',
+  headerContent: <FixedImage imageUrl="https://itizawa-tech.growi.cloud/attachment/61bb543444194e2b1d023552" />,
 };

--- a/src/components/parts/commons/Card/Card.tsx
+++ b/src/components/parts/commons/Card/Card.tsx
@@ -9,7 +9,7 @@ export const Card: FC<Props> = ({ imagePath, children }) => {
   return (
     <div className={classNames.join(' ')}>
       {imagePath && <img src={imagePath} className="card-img-top" alt="card-img-top" />}
-      <div className="card-body p-3">{children}</div>
+      <div className="card-body p-3 position-relative">{children}</div>
     </div>
   );
 };

--- a/src/components/parts/commons/Card/Card.tsx
+++ b/src/components/parts/commons/Card/Card.tsx
@@ -8,7 +8,7 @@ export const Card: FC<Props> = ({ imagePath, children }) => {
   const classNames = ['card border-0 shadow text-black overflow-hidden'];
   return (
     <div className={classNames.join(' ')}>
-      {imagePath && <img src={imagePath} className="card-img-top" alt="card-img-top" />}
+      {imagePath && <img src={imagePath} className="card-img-top h-auto" alt="card-img-top" width="1200" height="630" />}
       <div className="card-body p-3 position-relative">{children}</div>
     </div>
   );

--- a/src/components/parts/commons/Card/Card.tsx
+++ b/src/components/parts/commons/Card/Card.tsx
@@ -1,14 +1,13 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 
 type Props = {
-  imagePath?: string;
+  headerContent?: ReactNode;
 };
 
-export const Card: FC<Props> = ({ imagePath, children }) => {
-  const classNames = ['card border-0 shadow text-black overflow-hidden'];
+export const Card: FC<Props> = ({ headerContent, children }) => {
   return (
-    <div className={classNames.join(' ')}>
-      {imagePath && <img src={imagePath} className="card-img-top h-auto" alt="card-img-top" width="1200" height="630" />}
+    <div className="card border-0 shadow text-black overflow-hidden">
+      {headerContent}
       <div className="card-body p-3 position-relative">{children}</div>
     </div>
   );

--- a/src/components/parts/commons/FixedImage/FixedImage.stories.tsx
+++ b/src/components/parts/commons/FixedImage/FixedImage.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Box } from '@mui/system';
 
-import { FixedImage } from './FixedImage';
+import { FixedImage, SkeltonFixedImage } from './FixedImage';
 
 export default {
   title: 'parts/commons/FixedImage',
@@ -25,3 +25,13 @@ Default.args = {
 
 export const NotFound = Template.bind({});
 NotFound.args = {};
+
+const SkeltonTemplate: ComponentStory<typeof SkeltonFixedImage> = () => {
+  return (
+    <Box p="40px" bgcolor="#e5e5e5" width="400px">
+      <SkeltonFixedImage></SkeltonFixedImage>
+    </Box>
+  );
+};
+
+export const Skelton = SkeltonTemplate.bind({});

--- a/src/components/parts/commons/FixedImage/FixedImage.tsx
+++ b/src/components/parts/commons/FixedImage/FixedImage.tsx
@@ -31,7 +31,7 @@ const StyledSkeltonFixedImage = styled.div`
       background-color: rgba(0, 0, 0, 0.11);
     }
     50% {
-      background-color: rgba(255, 255, 255, 0.11);
+      background-color: rgba(0, 0, 0, 0.05);
     }
     100% {
       background-color: rgba(0, 0, 0, 0.11);

--- a/src/components/parts/commons/FixedImage/FixedImage.tsx
+++ b/src/components/parts/commons/FixedImage/FixedImage.tsx
@@ -1,10 +1,15 @@
 import { VFC } from 'react';
-import { styled } from '@mui/system';
+import styled from 'styled-components';
 import { IMAGE_PATH } from '~/constants';
 
 type Props = {
   imageUrl?: string;
 };
+
+export const SkeltonFixedImage: VFC = () => {
+  return <StyledSkeltonFixedImage></StyledSkeltonFixedImage>;
+};
+
 export const FixedImage: VFC<Props> = ({ imageUrl }) => {
   return (
     <StyledImageWrapper>
@@ -20,7 +25,25 @@ export const FixedImage: VFC<Props> = ({ imageUrl }) => {
   );
 };
 
-const StyledImageWrapper = styled('div')`
+const StyledSkeltonFixedImage = styled.div`
+  @keyframes loading {
+    0% {
+      background-color: rgba(0, 0, 0, 0.11);
+    }
+    50% {
+      background-color: rgba(255, 255, 255, 0.11);
+    }
+    100% {
+      background-color: rgba(0, 0, 0, 0.11);
+    }
+  }
+  width: 100%;
+  padding-top: 52.5%;
+  background-color: rgba(0, 0, 0, 0.11);
+  animation: loading 1.5s ease-in-out 0.5s infinite;
+`;
+
+const StyledImageWrapper = styled.div`
   position: relative;
   width: 100%;
   padding-top: 52.5%;

--- a/src/components/parts/commons/FixedImage/FixedImage.tsx
+++ b/src/components/parts/commons/FixedImage/FixedImage.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export const SkeltonFixedImage: VFC = () => {
-  return <StyledSkeltonFixedImage></StyledSkeltonFixedImage>;
+  return <StyledDiv className="w-100 skelton"></StyledDiv>;
 };
 
 export const FixedImage: VFC<Props> = ({ imageUrl }) => {
@@ -25,22 +25,8 @@ export const FixedImage: VFC<Props> = ({ imageUrl }) => {
   );
 };
 
-const StyledSkeltonFixedImage = styled.div`
-  @keyframes loading {
-    0% {
-      background-color: rgba(0, 0, 0, 0.11);
-    }
-    50% {
-      background-color: rgba(0, 0, 0, 0.05);
-    }
-    100% {
-      background-color: rgba(0, 0, 0, 0.11);
-    }
-  }
-  width: 100%;
+const StyledDiv = styled.div`
   padding-top: 52.5%;
-  background-color: rgba(0, 0, 0, 0.11);
-  animation: loading 1.5s ease-in-out 0.5s infinite;
 `;
 
 const StyledImageWrapper = styled.div`

--- a/src/components/parts/commons/FixedImage/index.ts
+++ b/src/components/parts/commons/FixedImage/index.ts
@@ -1,1 +1,1 @@
-export { FixedImage } from './FixedImage';
+export { FixedImage, SkeltonFixedImage } from './FixedImage';

--- a/src/components/parts/commons/index.tsx
+++ b/src/components/parts/commons/index.tsx
@@ -7,7 +7,7 @@ export { Emoji } from './Emoji';
 export { EmojiCountResult } from './EmojiCountResult';
 export { EmojiRadioGroup } from './EmojiRadioGroup';
 export { FirstLetterIcon } from './FirstLetterIcon';
-export { FixedImage } from './FixedImage';
+export { FixedImage, SkeltonFixedImage } from './FixedImage';
 export { Icon } from './Icon';
 export { IconUpload } from './IconUpload';
 export { Link } from './Link';

--- a/src/mocks/api/attachment.ts
+++ b/src/mocks/api/attachment.ts
@@ -9,11 +9,11 @@ const db = [
   }),
 ];
 
-export const getAttachmentById = (req: any, res: any, ctx: any) => {
+export const getAttachment = (req: any, res: any, ctx: any) => {
   const id = req.params.id;
   const attachment = db.find((v) => v._id === id);
 
-  return res(ctx.status(200), ctx.json({ signedUrl: attachment?.filePath }));
+  return res(ctx.status(200), attachment);
 };
 
 export const postAttachment = (req: any, res: any, ctx: any) => {

--- a/src/mocks/api/ogp.ts
+++ b/src/mocks/api/ogp.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Ogp } from '~/interfaces/ogp';
+
+const db = [
+  {
+    url: 'https://www.proeco.app/',
+    title: 'mockTitle',
+    image: 'https://www.proeco.app//images/twitter-ogp.png',
+    description: 'mockDescription',
+    siteName: 'mockSiteName',
+  } as Ogp,
+];
+
+export const getOgp = (req: any, res: any, ctx: any) => {
+  return res(ctx.status(200), ctx.json({ ogp: db[0] }));
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { rest } from 'msw';
-import { getAttachmentById, postAttachment } from './api/attachment';
+import { getAttachment, postAttachment } from './api/attachment';
 import { getCurrentUser } from './api/user';
 import { getStories, postStories } from './api/stories';
 import { getStoryPosts, postStoryPost, deleteStoryPost } from './api/storyPost';
@@ -13,7 +13,7 @@ const generateRoute = (path: string) => {
 export const handlers = [
   rest.get(generateRoute('/users/me'), getCurrentUser),
 
-  rest.get(generateRoute('/attachments/:id/signedUrl'), getAttachmentById),
+  rest.get(generateRoute('/attachments/:id'), getAttachment),
   rest.post(generateRoute('/attachments'), postAttachment),
 
   rest.get(generateRoute('/stories'), getStories),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,6 +5,7 @@ import { getStories, postStories } from './api/stories';
 import { getStoryPosts, postStoryPost, deleteStoryPost } from './api/storyPost';
 import { getReaction, postReaction, putReaction, deleteReaction } from './api/reaction';
 import { getTeam } from './api/team';
+import { getOgp } from './api/ogp';
 
 const generateRoute = (path: string) => {
   return `${process.env.NEXT_PUBLIC_BACKEND_URL_FROM_CLIENT}/api/v1${path}`;
@@ -29,4 +30,6 @@ export const handlers = [
   rest.delete(generateRoute('/reactions'), deleteReaction),
 
   rest.get(generateRoute('/teams/:id'), getTeam),
+
+  rest.get(generateRoute('/ogps'), getOgp),
 ];

--- a/src/pages/[productId]/story/[storyId].tsx
+++ b/src/pages/[productId]/story/[storyId].tsx
@@ -33,6 +33,7 @@ import { Breadcrumbs } from '~/components/parts/commons/Breadcrumbs';
 import { PaginationResult } from '~/interfaces';
 
 import { useErrorNotification } from '~/hooks/useErrorNotification';
+import { createOgpUrl } from '~/utils/createOgpUrl';
 
 type Props = {
   storyFromServerSide: Story;
@@ -117,10 +118,7 @@ const StoryPage: ProecoNextPage<Props> = ({ storyFromServerSide, team, teamIconA
   ];
 
   const ogpUrl = useMemo(
-    () =>
-      story
-        ? `https://proeco-ogp.vercel.app/api/ogp?title=${story.title}&teamName=${team.name}&teamIconUrl=${teamIconAttachment.filePath}`
-        : '',
+    () => (story ? createOgpUrl(story.title, team.name, teamIconAttachment.filePath) : ''),
     [story, team.name, teamIconAttachment],
   );
 

--- a/src/styles/custom-utility.scss
+++ b/src/styles/custom-utility.scss
@@ -17,3 +17,19 @@
 .c-pointer {
   cursor: pointer;
 }
+
+.skelton {
+  @keyframes loading {
+    0% {
+      background-color: rgba(0, 0, 0, 0.11);
+    }
+    50% {
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+    100% {
+      background-color: rgba(0, 0, 0, 0.11);
+    }
+  }
+  background-color: rgba(0, 0, 0, 0.11);
+  animation: loading 1.5s ease-in-out 0.5s infinite;
+}

--- a/src/utils/createOgpUrl/createOgpUrl.ts
+++ b/src/utils/createOgpUrl/createOgpUrl.ts
@@ -1,0 +1,10 @@
+/**
+ * ogpのurlを返すutil
+ * @param title string
+ * @param teamName string
+ * @param teamIconUrl string
+ * @returns string
+ */
+export const createOgpUrl = (title: string, teamName: string, teamIconUrl: string) => {
+  return `https://proeco-ogp.vercel.app/api/ogp?title=${title}&teamName=${teamName}&teamIconUrl=${teamIconUrl}`;
+};

--- a/src/utils/createOgpUrl/index.ts
+++ b/src/utils/createOgpUrl/index.ts
@@ -1,0 +1,1 @@
+export { createOgpUrl } from './createOgpUrl';


### PR DESCRIPTION
## 対象IssueのLink
close #540

## 変更箇所

- StoryCardに、storyのOGPが表示されるように実装
- StoryCardとTeamCardの画像をCardにimagePathを渡して表示するように修正
- storybookでStoryCardとTeamCardの画像が表示されるように実装