### PR TITLE
参加確認画面のアクセス時のリダイレクトを実装

### DIFF
--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -1,15 +1,51 @@
+import { GetServerSideProps } from 'next';
 import { ReactNode } from 'react';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
+import { InvitationToken, Team } from '~/domains';
+import { PaginationResult } from '~/interfaces';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
+import { restClient } from '~/utils/rest-client';
 
-const InvitePage: ProecoNextPage = () => {
+type Props = {
+  team: Team;
+};
+
+const InvitePage: ProecoNextPage<Props> = ({ team }) => {
   return (
     <>
       <ProecoOgpHead />
-      <h1>参加確認画面</h1>
+      <h1>{team.name}の参加確認画面</h1>
     </>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { productId, token } = context.query;
+
+  try {
+    const { data: invitationToken } = await restClient.apiGet<InvitationToken>(`/invitation-tokens/${token}`);
+    const { data: pagination } = await restClient.apiGet<PaginationResult<Team>>(`/teams?productId=${productId}`);
+    const team = pagination?.docs[0];
+
+    if (!invitationToken || invitationToken.teamId !== team._id) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: '/404',
+        },
+      };
+    }
+
+    return { props: { team } };
+  } catch (error) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/404',
+      },
+    };
+  }
 };
 
 InvitePage.getLayout = (page: ReactNode) => <DashboardLayout>{page}</DashboardLayout>;

--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -1,11 +1,14 @@
 import { GetServerSideProps } from 'next';
 import { ReactNode } from 'react';
+import { addDays, isPast } from 'date-fns';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
 import { InvitationToken, Team } from '~/domains';
 import { PaginationResult } from '~/interfaces';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
 import { restClient } from '~/utils/rest-client';
+
+const TOKEN_LIMIT_DAYS = 7;
 
 type Props = {
   team: Team;
@@ -28,7 +31,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const { data: pagination } = await restClient.apiGet<PaginationResult<Team>>(`/teams?productId=${productId}`);
     const team = pagination?.docs[0];
 
-    if (!invitationToken || invitationToken.teamId !== team._id) {
+    if (!invitationToken || invitationToken.teamId !== team._id || isPast(addDays(new Date(invitationToken.createdAt), TOKEN_LIMIT_DAYS))) {
       return {
         redirect: {
           permanent: false,

--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
+import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
+import { ProecoNextPage } from '~/interfaces/proecoNextPage';
+
+const InvitePage: ProecoNextPage = () => {
+  return (
+    <>
+      <ProecoOgpHead />
+      <h1>参加確認画面</h1>
+    </>
+  );
+};
+
+InvitePage.getLayout = (page: ReactNode) => <DashboardLayout>{page}</DashboardLayout>;
+InvitePage.getAccessControl = () => {
+  return { loginRequired: null };
+};
+
+export default InvitePage;


### PR DESCRIPTION
## 対象IssueのLink
close #555 

## 変更箇所
- 参加確認画面にアクセスした際に、apiを叩いてtokenとurlのparams の token が一致するinvitationTokenを取得する。
- 存在しなかった or 期限が切れている or urlのproductIdのteamとinvitationTokenに紐づいているteamが異なっていた場合に 404 にリダイレクトする。


