### PR TITLE
参加確認画面の参加を受諾した場合の処理を実装

### DIFF
--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -12,6 +12,8 @@ import { Button } from '~/components/parts/commons';
 import { LoginModal } from '~/components/parts/authentication/LoginModal';
 import { useCurrentUser } from '~/stores/user/useCurrentUser';
 import { URLS } from '~/constants';
+import { useErrorNotification } from '~/hooks/useErrorNotification';
+import { useSuccessNotification } from '~/hooks/useSuccessNotification';
 
 const TOKEN_LIMIT_DAYS = 7;
 
@@ -24,10 +26,25 @@ const InvitePage: ProecoNextPage<Props> = ({ team }) => {
 
   const { data: currentUser } = useCurrentUser();
   const router = useRouter();
+  const { notifySuccessMessage } = useSuccessNotification();
+  const { notifyErrorMessage } = useErrorNotification();
 
   useEffect(() => {
     currentUser ? setIsLoginModalOpen(false) : setIsLoginModalOpen(true);
   }, [currentUser]);
+
+  const handleApproveInvite = async () => {
+    try {
+      await restClient.apiPost<InvitationToken>('/user-team-relations', {
+        token: router.query.token,
+      });
+      notifySuccessMessage('チームに参加しました！');
+    } catch (error) {
+      notifyErrorMessage('チームへの参加に失敗しました。');
+    }
+
+    router.push(URLS.TEAMS(team.productId));
+  };
 
   const handleRejectInvite = () => {
     router.push(URLS.TOP);
@@ -38,7 +55,9 @@ const InvitePage: ProecoNextPage<Props> = ({ team }) => {
       <ProecoOgpHead />
       <h1>{team.name}の参加確認画面</h1>
       <div className="d-flex align-items-center gap-2">
-        <Button color="primary">チームに参加する</Button>
+        <Button color="primary" onClick={handleApproveInvite}>
+          チームに参加する
+        </Button>
         <Button color="primary" onClick={handleRejectInvite}>
           チームに参加しない
         </Button>

--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -1,5 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { addDays, isPast } from 'date-fns';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
 import { InvitationToken, Team } from '~/domains';
@@ -7,6 +9,9 @@ import { PaginationResult } from '~/interfaces';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
 import { restClient } from '~/utils/rest-client';
 import { Button } from '~/components/parts/commons';
+import { LoginModal } from '~/components/parts/authentication/LoginModal';
+import { useCurrentUser } from '~/stores/user/useCurrentUser';
+import { URLS } from '~/constants';
 
 const TOKEN_LIMIT_DAYS = 7;
 
@@ -15,14 +20,30 @@ type Props = {
 };
 
 const InvitePage: ProecoNextPage<Props> = ({ team }) => {
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+
+  const { data: currentUser } = useCurrentUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    currentUser ? setIsLoginModalOpen(false) : setIsLoginModalOpen(true);
+  }, [currentUser]);
+
+  const handleRejectInvite = () => {
+    router.push(URLS.TOP);
+  };
+
   return (
     <DashboardLayout>
       <ProecoOgpHead />
       <h1>{team.name}の参加確認画面</h1>
       <div className="d-flex align-items-center gap-2">
         <Button color="primary">チームに参加する</Button>
-        <Button color="primary">チームに参加しない</Button>
+        <Button color="primary" onClick={handleRejectInvite}>
+          チームに参加しない
+        </Button>
       </div>
+      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
     </DashboardLayout>
   );
 };

--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -14,6 +14,7 @@ import { useCurrentUser } from '~/stores/user/useCurrentUser';
 import { URLS } from '~/constants';
 import { useErrorNotification } from '~/hooks/useErrorNotification';
 import { useSuccessNotification } from '~/hooks/useSuccessNotification';
+import { useTeamUsers } from '~/stores/team';
 
 const TOKEN_LIMIT_DAYS = 7;
 
@@ -25,13 +26,19 @@ const InvitePage: ProecoNextPage<Props> = ({ team }) => {
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
   const { data: currentUser } = useCurrentUser();
+  const { data: teamUsers = [] } = useTeamUsers({ teamId: team._id });
   const router = useRouter();
   const { notifySuccessMessage } = useSuccessNotification();
   const { notifyErrorMessage } = useErrorNotification();
 
   useEffect(() => {
     currentUser ? setIsLoginModalOpen(false) : setIsLoginModalOpen(true);
-  }, [currentUser]);
+
+    if (currentUser && teamUsers.some((teamUser) => teamUser._id === currentUser._id)) {
+      notifySuccessMessage('すでにチームに所属しています');
+      router.push(URLS.TEAMS(team.productId));
+    }
+  }, [currentUser, teamUsers, team, router, notifySuccessMessage]);
 
   const handleApproveInvite = async () => {
     try {
@@ -54,14 +61,14 @@ const InvitePage: ProecoNextPage<Props> = ({ team }) => {
     <DashboardLayout>
       <ProecoOgpHead />
       <h1>{team.name}の参加確認画面</h1>
-      <div className="d-flex align-items-center gap-2">
+      <div className="mb-4">
         <Button color="primary" onClick={handleApproveInvite}>
           チームに参加する
         </Button>
-        <Button color="primary" onClick={handleRejectInvite}>
-          チームに参加しない
-        </Button>
       </div>
+      <Button color="primary" onClick={handleRejectInvite}>
+        Topページに戻る
+      </Button>
       <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
     </DashboardLayout>
   );

--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -6,6 +6,7 @@ import { InvitationToken, Team } from '~/domains';
 import { PaginationResult } from '~/interfaces';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
 import { restClient } from '~/utils/rest-client';
+import { Button } from '~/components/parts/commons';
 
 const TOKEN_LIMIT_DAYS = 7;
 
@@ -18,6 +19,10 @@ const InvitePage: ProecoNextPage<Props> = ({ team }) => {
     <DashboardLayout>
       <ProecoOgpHead />
       <h1>{team.name}の参加確認画面</h1>
+      <div className="d-flex align-items-center gap-2">
+        <Button color="primary">チームに参加する</Button>
+        <Button color="primary">チームに参加しない</Button>
+      </div>
     </DashboardLayout>
   );
 };

--- a/src/pages/[productId]/invite/[token].tsx
+++ b/src/pages/[productId]/invite/[token].tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { DashboardLayout } from '~/components/parts/layout/DashboardLayout';
 import { ProecoOgpHead } from '~/components/parts/layout/ProecoOgpHead';
-import { InvitationToken, Team } from '~/domains';
+import { InvitationToken, Team, UserTeamRelation } from '~/domains';
 import { PaginationResult } from '~/interfaces';
 import { ProecoNextPage } from '~/interfaces/proecoNextPage';
 import { restClient } from '~/utils/rest-client';
@@ -23,7 +23,7 @@ type Props = {
 
 const InvitePage: ProecoNextPage<Props> = ({ team }) => {
   const { data: currentUser, isValidating: isValidatingCurrentUser } = useCurrentUser();
-  const { data: teamUsers = [] } = useTeamUsers({ teamId: team._id });
+  const { data: teamUsers = [], mutate: mutateTeamUsers } = useTeamUsers({ teamId: team._id });
   const router = useRouter();
   const { notifySuccessMessage } = useSuccessNotification();
   const { notifyErrorMessage } = useErrorNotification();
@@ -44,15 +44,15 @@ const InvitePage: ProecoNextPage<Props> = ({ team }) => {
 
   const handleApproveInvite = async () => {
     try {
-      await restClient.apiPost<InvitationToken>('/user-team-relations', {
+      await restClient.apiPost<UserTeamRelation>('/user-team-relations', {
         token: router.query.token,
       });
+      await mutateTeamUsers();
       notifySuccessMessage('チームに参加しました！');
+      router.push(URLS.TEAMS(team.productId));
     } catch (error) {
       notifyErrorMessage('チームへの参加に失敗しました。');
     }
-
-    router.push(URLS.TEAMS(team.productId));
   };
 
   const handleRejectInvite = () => {

--- a/src/stores/team/useTeamUsers.tsx
+++ b/src/stores/team/useTeamUsers.tsx
@@ -1,5 +1,5 @@
 import { SWRResponse } from 'swr';
-import useSWR from 'swr/immutable';
+import useImmutableSWR from 'swr/immutable';
 
 import { convertUserFromServer, User } from '~/domains';
 import { PaginationResult } from '~/interfaces';
@@ -14,7 +14,7 @@ import { restClient } from '~/utils/rest-client';
  */
 export const useTeamUsers = ({ teamId }: { teamId?: string }): SWRResponse<User[], Error> => {
   const key = teamId ? `/teams/${teamId}/users` : null;
-  return useSWR(
+  return useImmutableSWR(
     key,
     (endpoint: string) =>
       restClient.apiGet<PaginationResult<User>>(endpoint).then((result) => result.data.docs.map((v) => convertUserFromServer(v))),

--- a/src/stores/team/useTeamUsers.tsx
+++ b/src/stores/team/useTeamUsers.tsx
@@ -1,5 +1,5 @@
 import { SWRResponse } from 'swr';
-import useImmutableSWR from 'swr/immutable';
+import useSWR from 'swr/immutable';
 
 import { convertUserFromServer, User } from '~/domains';
 import { PaginationResult } from '~/interfaces';
@@ -14,7 +14,7 @@ import { restClient } from '~/utils/rest-client';
  */
 export const useTeamUsers = ({ teamId }: { teamId?: string }): SWRResponse<User[], Error> => {
   const key = teamId ? `/teams/${teamId}/users` : null;
-  return useImmutableSWR(
+  return useSWR(
     key,
     (endpoint: string) =>
       restClient.apiGet<PaginationResult<User>>(endpoint).then((result) => result.data.docs.map((v) => convertUserFromServer(v))),


### PR DESCRIPTION
## 対象IssueのLink
close #556 

## 変更箇所
- ログインしていない場合、「ログイン後再度招待リンクを開いてください」を表示してチーム画面に遷移
- ログインユーザーがすでにチームに所属していた場合、「すでにチームに所属しています」を表示してチーム画面に遷移
- 参加を受諾した場合、UserTeamRelationを作成し、チーム画面に遷移
- 「Topページに戻る」ボタンを設置


