### PR TITLE
「招待リンクの作成」ボタンを実装

### DIFF
--- a/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
+++ b/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
@@ -21,20 +21,17 @@ export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
   const [activeContent, setActiveContent] = useState('basic');
 
   useEffect(() => {
-    if (!router) return;
+    if (!router.query.content) return;
     setActiveContent(router.query.content as string);
   }, [router]);
 
   const handleCreateInviteLink = async () => {
     try {
-      const { data: invitationToken } = await restClient.apiPost<InvitationToken>('/invitation-tokens', {
+      await restClient.apiPost<InvitationToken>('/invitation-tokens', {
         teamId: team._id,
       });
 
-      const inviteLink = `${process.env.NEXT_PUBLIC_ROOT_URL}/${team.productId}/invite/${invitationToken.token}`;
-
-      navigator.clipboard.writeText(inviteLink);
-      notifySuccessMessage('招待リンクをコピーしました!');
+      notifySuccessMessage('招待リンクを作成しました!');
     } catch (error) {
       notifyErrorMessage('招待リンクの作成に失敗しました!');
     }
@@ -57,6 +54,7 @@ export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
         <div className="col-12 col-md-9">
           {activeContent === 'basic' && <TeamForm currentUser={currentUser} team={team} />}
           {activeContent === 'team' && (
+            // TODO チーム設定のコンテンツ部分を別componentにする
             <Button color="primary" onClick={handleCreateInviteLink}>
               招待リンクを作成
             </Button>

--- a/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
+++ b/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
@@ -1,6 +1,11 @@
 import React, { VFC } from 'react';
 import { TeamForm } from '~/components/domains/team/TeamForm';
-import { Team, User } from '~/domains';
+import { Button } from '~/components/parts/commons';
+import { URLS } from '~/constants';
+import { InvitationToken, Team, User } from '~/domains';
+import { useErrorNotification } from '~/hooks/useErrorNotification';
+import { useSuccessNotification } from '~/hooks/useSuccessNotification';
+import { restClient } from '~/utils/rest-client';
 
 type Props = {
   currentUser: User;
@@ -8,12 +13,28 @@ type Props = {
 };
 
 export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
+  const { notifySuccessMessage } = useSuccessNotification();
+  const { notifyErrorMessage } = useErrorNotification();
+  const handleCreateInviteLink = async () => {
+    try {
+      await restClient.apiPost<InvitationToken>('/invitation-tokens', {
+        teamId: team._id,
+      });
+
+      notifySuccessMessage('招待リンクの作成に成功しました!');
+    } catch (error) {
+      notifyErrorMessage('招待リンクの作成に失敗しました!');
+    }
+  };
   return (
     <>
       <div className="row gy-3">
         <div className="list-group col-12 col-md-3">
           <a href="#" className="list-group-item list-group-item-action active" aria-current="true">
             基本設定
+          </a>
+          <a href={URLS.TEAMS_SETTINGS(team.productId) + '?tab=team'} className="list-group-item list-group-item-action" aria-current="true">
+            チーム設定
           </a>
           {/* TODO */}
           {/* <a href="#" className="list-group-item list-group-item-action">
@@ -22,6 +43,9 @@ export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
         </div>
         <div className="col-12 col-md-9">
           <TeamForm currentUser={currentUser} team={team} />
+          <Button color="primary" onClick={handleCreateInviteLink}>
+            招待リンクを作成
+          </Button>
         </div>
       </div>
     </>

--- a/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
+++ b/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
@@ -1,6 +1,7 @@
-import React, { VFC } from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState, VFC } from 'react';
 import { TeamForm } from '~/components/domains/team/TeamForm';
-import { Button } from '~/components/parts/commons';
+import { Button, Link } from '~/components/parts/commons';
 import { URLS } from '~/constants';
 import { InvitationToken, Team, User } from '~/domains';
 import { useErrorNotification } from '~/hooks/useErrorNotification';
@@ -15,6 +16,15 @@ type Props = {
 export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
   const { notifySuccessMessage } = useSuccessNotification();
   const { notifyErrorMessage } = useErrorNotification();
+  const router = useRouter();
+
+  const [activeContent, setActiveContent] = useState('basic');
+
+  useEffect(() => {
+    if (!router) return;
+    setActiveContent(router.query.content as string);
+  }, [router]);
+
   const handleCreateInviteLink = async () => {
     try {
       const { data: invitationToken } = await restClient.apiPost<InvitationToken>('/invitation-tokens', {
@@ -33,22 +43,24 @@ export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
     <>
       <div className="row gy-3">
         <div className="list-group col-12 col-md-3">
-          <a href="#" className="list-group-item list-group-item-action active" aria-current="true">
-            基本設定
-          </a>
-          <a href={URLS.TEAMS_SETTINGS(team.productId) + '?tab=team'} className="list-group-item list-group-item-action" aria-current="true">
-            チーム設定
-          </a>
+          <Link href={URLS.TEAMS_SETTINGS(team.productId) + '?content=basic'}>
+            <span className={`list-group-item list-group-item-action rounded ${activeContent === 'basic' && 'active'}`}>基本設定</span>
+          </Link>
+          <Link href={URLS.TEAMS_SETTINGS(team.productId) + '?content=team'}>
+            <span className={`list-group-item list-group-item-action rounded ${activeContent === 'team' && 'active'}`}>チーム設定</span>
+          </Link>
           {/* TODO */}
           {/* <a href="#" className="list-group-item list-group-item-action">
             重要な設定
           </a> */}
         </div>
         <div className="col-12 col-md-9">
-          <TeamForm currentUser={currentUser} team={team} />
-          <Button color="primary" onClick={handleCreateInviteLink}>
-            招待リンクを作成
-          </Button>
+          {activeContent === 'basic' && <TeamForm currentUser={currentUser} team={team} />}
+          {activeContent === 'team' && (
+            <Button color="primary" onClick={handleCreateInviteLink}>
+              招待リンクを作成
+            </Button>
+          )}
         </div>
       </div>
     </>

--- a/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
+++ b/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
@@ -17,11 +17,14 @@ export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
   const { notifyErrorMessage } = useErrorNotification();
   const handleCreateInviteLink = async () => {
     try {
-      await restClient.apiPost<InvitationToken>('/invitation-tokens', {
+      const { data: invitationToken } = await restClient.apiPost<InvitationToken>('/invitation-tokens', {
         teamId: team._id,
       });
 
-      notifySuccessMessage('招待リンクの作成に成功しました!');
+      const inviteLink = `${process.env.NEXT_PUBLIC_ROOT_URL}/${team.productId}/invite/${invitationToken.token}`;
+
+      navigator.clipboard.writeText(inviteLink);
+      notifySuccessMessage('招待リンクをコピーしました!');
     } catch (error) {
       notifyErrorMessage('招待リンクの作成に失敗しました!');
     }

--- a/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
+++ b/src/components/domains/team/TeamSettingTab/TeamSettingTab.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { useEffect, useState, VFC } from 'react';
 import { TeamForm } from '~/components/domains/team/TeamForm';
-import { Button, Link } from '~/components/parts/commons';
+import { Button } from '~/components/parts/commons';
 import { URLS } from '~/constants';
 import { InvitationToken, Team, User } from '~/domains';
 import { useErrorNotification } from '~/hooks/useErrorNotification';
@@ -25,6 +25,10 @@ export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
     setActiveContent(router.query.content as string);
   }, [router]);
 
+  const handleClickSideMenu = (name: string) => {
+    router.push(URLS.TEAMS_SETTINGS(team.productId) + `?content=${name}`);
+  };
+
   const handleCreateInviteLink = async () => {
     try {
       await restClient.apiPost<InvitationToken>('/invitation-tokens', {
@@ -40,12 +44,18 @@ export const TeamSettingTab: VFC<Props> = ({ currentUser, team }) => {
     <>
       <div className="row gy-3">
         <div className="list-group col-12 col-md-3">
-          <Link href={URLS.TEAMS_SETTINGS(team.productId) + '?content=basic'}>
-            <span className={`list-group-item list-group-item-action rounded ${activeContent === 'basic' && 'active'}`}>基本設定</span>
-          </Link>
-          <Link href={URLS.TEAMS_SETTINGS(team.productId) + '?content=team'}>
-            <span className={`list-group-item list-group-item-action rounded ${activeContent === 'team' && 'active'}`}>チーム設定</span>
-          </Link>
+          <span
+            className={`list-group-item list-group-item-action rounded ${activeContent === 'basic' && 'active'}`}
+            onClick={() => handleClickSideMenu('basic')}
+          >
+            基本設定
+          </span>
+          <span
+            className={`list-group-item list-group-item-action rounded ${activeContent === 'team' && 'active'}`}
+            onClick={() => handleClickSideMenu('team')}
+          >
+            チーム設定
+          </span>
           {/* TODO */}
           {/* <a href="#" className="list-group-item list-group-item-action">
             重要な設定


### PR DESCRIPTION
## 対象IssueのLink
close #554 

## 変更箇所
- TeamSettingTabにボタンを設置
- ボタンをクリック時に、apiを叩いてInvitationTokenを生成する
- サイドバーのメニューの基本設定とチーム設定でコンテンツを切り替えれるように実装

