### PR TITLE
プロダクトの設定画面でリロードするとプロダクトのホーム画面に遷移してしまうのを修正

### DIFF
--- a/src/pages/[productId]/settings/index.tsx
+++ b/src/pages/[productId]/settings/index.tsx
@@ -26,19 +26,19 @@ const Dashboard: ProecoNextPage<Props> = ({ team }) => {
   const { data: currentUser, isValidating: isValidatingCurrentUser } = useCurrentUser();
   const router = useRouter();
 
-  const { data: teamUsers = [] } = useTeamUsers({ teamId: team?._id });
+  const { data: teamUsers = [], isValidating: isValidatingTeamUsers } = useTeamUsers({ teamId: team?._id });
   const isMemberOfTeam = useMemo(() => {
     return !!currentUser && teamUsers.some((teamUser) => teamUser._id === currentUser._id);
   }, [currentUser, teamUsers]);
 
   useEffect(() => {
     if (!team) return;
-    if (teamUsers.length === 0) return;
+    if (isValidatingTeamUsers) return;
 
-    if ((!currentUser && !isValidatingCurrentUser) || (currentUser && !isMemberOfTeam)) {
+    if (!isValidatingCurrentUser && !isMemberOfTeam) {
       router.push(URLS.TEAMS(team.productId));
     }
-  }, [currentUser, team, router, isValidatingCurrentUser, isMemberOfTeam, teamUsers]);
+  }, [team, router, isValidatingCurrentUser, isMemberOfTeam, isValidatingTeamUsers]);
 
   if (!team) {
     return (

--- a/src/pages/[productId]/settings/index.tsx
+++ b/src/pages/[productId]/settings/index.tsx
@@ -32,10 +32,13 @@ const Dashboard: ProecoNextPage<Props> = ({ team }) => {
   }, [currentUser, teamUsers]);
 
   useEffect(() => {
-    if (team && ((!currentUser && !isValidatingCurrentUser) || !isMemberOfTeam)) {
+    if (!team) return;
+    if (teamUsers.length === 0) return;
+
+    if ((!currentUser && !isValidatingCurrentUser) || (currentUser && !isMemberOfTeam)) {
       router.push(URLS.TEAMS(team.productId));
     }
-  }, [currentUser, team, router, isValidatingCurrentUser, isMemberOfTeam]);
+  }, [currentUser, team, router, isValidatingCurrentUser, isMemberOfTeam, teamUsers]);
 
   if (!team) {
     return (


### PR DESCRIPTION
## 対象IssueのLink
close #706 

## 変更箇所
プロダクトのメンバーがプロダクトの設定画面でリロードしても、プロダクトのホーム画面に遷移してしまわないように修正しました



