### PR TITLE
メンバー設定画面で、チームメンバーを一覧表示する

### DIFF
--- a/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
+++ b/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, VFC } from 'react';
 
+import { DeleteTeamMemberModal } from '../DeleteTeamMemberModal';
 import { UserIcon } from '~/components/domains/user/UserIcon';
 import { ManageInviteLinkModal } from '~/components/domains/team/ManageInviteLinkModal';
 import { Button, Card, Dropdown, DropdownItem, Icon, Tooltip } from '~/components/parts/commons';
@@ -12,10 +13,6 @@ type Props = {
 
 export const TeamMemberSettingCard: VFC<Props> = ({ team, currentUser }) => {
   const [isOpenManageInviteLinkModal, setIsOpenManageInviteLinkModal] = useState(false);
-
-  const handleClickUpdate = () => {};
-
-  const handleClickDelete = () => {};
 
   const menuItems = [
     {

--- a/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
+++ b/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
@@ -1,7 +1,8 @@
 import React, { useState, VFC } from 'react';
 
+import { UserIcon } from '~/components/domains/user/UserIcon';
 import { ManageInviteLinkModal } from '~/components/domains/team/ManageInviteLinkModal';
-import { Button, Card, Tooltip } from '~/components/parts/commons';
+import { Button, Card, Dropdown, DropdownItem, Icon, Tooltip } from '~/components/parts/commons';
 import { Team, User } from '~/domains';
 
 type Props = {
@@ -12,6 +13,23 @@ type Props = {
 export const TeamMemberSettingCard: VFC<Props> = ({ team, currentUser }) => {
   const [isOpenManageInviteLinkModal, setIsOpenManageInviteLinkModal] = useState(false);
 
+  const handleClickUpdate = () => {};
+
+  const handleClickDelete = () => {};
+
+  const menuItems = [
+    {
+      icon: <Icon icon="CLOCKWISE" size={16} />,
+      text: 'プロダクトの管理者を変更する',
+      onClick: handleClickUpdate,
+    },
+    {
+      icon: <Icon icon="TRASH" size={16} color="DANGER" />,
+      text: 'プロダクトから削除する',
+      onClick: handleClickDelete,
+    },
+  ];
+
   return (
     <>
       <Card>
@@ -20,6 +38,35 @@ export const TeamMemberSettingCard: VFC<Props> = ({ team, currentUser }) => {
             メンバーを招待する
           </Button>
         </Tooltip>
+        <table className="table mt-3">
+          <thead>
+            <tr>
+              <th scope="col">アイコン</th>
+              <th scope="col">ユーザー名</th>
+              <th scope="col">ステータス</th>
+              <th scope="col"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="align-middle">
+              <th scope="row">
+                <UserIcon size={40} />
+              </th>
+              <td>カノイ</td>
+              <td>メンバー</td>
+              <td className="text-end">
+                <Dropdown toggle={<Icon icon="THREE_DOTS_VERTICAL" size={20} />} tag="span">
+                  {menuItems.map((menuItem, i) => (
+                    <DropdownItem key={i} onClick={menuItem.onClick}>
+                      {menuItem.icon}
+                      <span className="ms-2">{menuItem.text}</span>
+                    </DropdownItem>
+                  ))}
+                </Dropdown>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </Card>
       <ManageInviteLinkModal team={team} isOpen={isOpenManageInviteLinkModal} onCloseModal={() => setIsOpenManageInviteLinkModal(false)} />
     </>

--- a/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
+++ b/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
@@ -35,7 +35,7 @@ export const TeamMemberSettingCard: VFC<Props> = ({ team, currentUser }) => {
           </thead>
           <tbody>
             {teamUsers.map((user) => (
-              <TeamMemberTableRow key={user._id} team={team} user={user} />
+              <TeamMemberTableRow key={user._id} team={team} user={user} currentUser={currentUser} />
             ))}
           </tbody>
         </table>

--- a/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
+++ b/src/components/domains/team/TeamMemberSettingCard/TeamMemberSettingCard.tsx
@@ -1,10 +1,10 @@
 import React, { useState, VFC } from 'react';
 
-import { DeleteTeamMemberModal } from '../DeleteTeamMemberModal';
-import { UserIcon } from '~/components/domains/user/UserIcon';
+import { TeamMemberTableRow } from '../TeamMemberTableRow';
 import { ManageInviteLinkModal } from '~/components/domains/team/ManageInviteLinkModal';
-import { Button, Card, Dropdown, DropdownItem, Icon, Tooltip } from '~/components/parts/commons';
+import { Button, Card, Tooltip } from '~/components/parts/commons';
 import { Team, User } from '~/domains';
+import { useTeamUsers } from '~/stores/team';
 
 type Props = {
   team: Team;
@@ -14,18 +14,7 @@ type Props = {
 export const TeamMemberSettingCard: VFC<Props> = ({ team, currentUser }) => {
   const [isOpenManageInviteLinkModal, setIsOpenManageInviteLinkModal] = useState(false);
 
-  const menuItems = [
-    {
-      icon: <Icon icon="CLOCKWISE" size={16} />,
-      text: 'プロダクトの管理者を変更する',
-      onClick: handleClickUpdate,
-    },
-    {
-      icon: <Icon icon="TRASH" size={16} color="DANGER" />,
-      text: 'プロダクトから削除する',
-      onClick: handleClickDelete,
-    },
-  ];
+  const { data: teamUsers = [] } = useTeamUsers({ teamId: team._id });
 
   return (
     <>
@@ -45,23 +34,9 @@ export const TeamMemberSettingCard: VFC<Props> = ({ team, currentUser }) => {
             </tr>
           </thead>
           <tbody>
-            <tr className="align-middle">
-              <th scope="row">
-                <UserIcon size={40} />
-              </th>
-              <td>カノイ</td>
-              <td>メンバー</td>
-              <td className="text-end">
-                <Dropdown toggle={<Icon icon="THREE_DOTS_VERTICAL" size={20} />} tag="span">
-                  {menuItems.map((menuItem, i) => (
-                    <DropdownItem key={i} onClick={menuItem.onClick}>
-                      {menuItem.icon}
-                      <span className="ms-2">{menuItem.text}</span>
-                    </DropdownItem>
-                  ))}
-                </Dropdown>
-              </td>
-            </tr>
+            {teamUsers.map((user) => (
+              <TeamMemberTableRow key={user._id} team={team} user={user} />
+            ))}
           </tbody>
         </table>
       </Card>

--- a/src/components/domains/team/TeamMemberTableRow/TeamMemberTableRow.tsx
+++ b/src/components/domains/team/TeamMemberTableRow/TeamMemberTableRow.tsx
@@ -1,0 +1,64 @@
+import React, { useState, VFC } from 'react';
+
+import { DeleteTeamMemberModal } from '../DeleteTeamMemberModal';
+import { UpdateAdminUserOfTeamModal } from '../UpdateAdminUserOfTeamModal';
+import { UserIcon } from '~/components/domains/user/UserIcon';
+
+import { Team, User } from '~/domains';
+import { Dropdown, DropdownItem, Icon } from '~/components/parts/commons';
+
+type Props = {
+  user: User;
+  team: Team;
+};
+
+export const TeamMemberTableRow: VFC<Props> = ({ user, team }) => {
+  const [isDeleteTeamMemberModal, setIsDeleteTeamMemberModal] = useState(false);
+  const [isUpdateAdminUserOfTeamModal, setIsUpdateAdminUserOfTeamModal] = useState(false);
+
+  const menuItems = [
+    {
+      icon: <Icon icon="CLOCKWISE" size={16} />,
+      text: 'プロダクトの管理者を変更する',
+      onClick: () => setIsUpdateAdminUserOfTeamModal(true),
+    },
+    {
+      icon: <Icon icon="TRASH" size={16} color="DANGER" />,
+      text: 'プロダクトから削除する',
+      onClick: () => setIsDeleteTeamMemberModal(true),
+    },
+  ];
+
+  return (
+    <tr className="align-middle">
+      <th scope="row">
+        <UserIcon attachmentId={user.iconImageId} userId={user._id} size={40} />
+      </th>
+      <td>カノイ</td>
+      <td>メンバー</td>
+      <td className="text-end">
+        <Dropdown toggle={<Icon icon="THREE_DOTS_VERTICAL" size={20} />} tag="span">
+          {menuItems.map((menuItem, i) => (
+            <DropdownItem key={i} onClick={menuItem.onClick}>
+              {menuItem.icon}
+              <span className="ms-2">{menuItem.text}</span>
+            </DropdownItem>
+          ))}
+        </Dropdown>
+      </td>
+      <DeleteTeamMemberModal
+        isOpen={isDeleteTeamMemberModal}
+        onCloseModal={() => setIsDeleteTeamMemberModal(false)}
+        userId={user._id}
+        teamId={team._id}
+      />
+      <UpdateAdminUserOfTeamModal
+        isOpen={isUpdateAdminUserOfTeamModal}
+        onCloseModal={() => setIsUpdateAdminUserOfTeamModal(false)}
+        userId={user._id}
+        userName={user.name}
+        teamId={team._id}
+      />
+    </tr>
+  );
+};

--- a/src/components/domains/team/TeamMemberTableRow/TeamMemberTableRow.tsx
+++ b/src/components/domains/team/TeamMemberTableRow/TeamMemberTableRow.tsx
@@ -34,8 +34,8 @@ export const TeamMemberTableRow: VFC<Props> = ({ user, team }) => {
       <th scope="row">
         <UserIcon attachmentId={user.iconImageId} userId={user._id} size={40} />
       </th>
-      <td>カノイ</td>
-      <td>メンバー</td>
+      <td>{user.name}</td>
+      <td>{team.adminUserId === user._id ? '管理者' : 'メンバー'}</td>
       <td className="text-end">
         <Dropdown toggle={<Icon icon="THREE_DOTS_VERTICAL" size={20} />} tag="span">
           {menuItems.map((menuItem, i) => (

--- a/src/components/domains/team/TeamMemberTableRow/TeamMemberTableRow.tsx
+++ b/src/components/domains/team/TeamMemberTableRow/TeamMemberTableRow.tsx
@@ -9,10 +9,11 @@ import { Dropdown, DropdownItem, Icon } from '~/components/parts/commons';
 
 type Props = {
   user: User;
+  currentUser: User;
   team: Team;
 };
 
-export const TeamMemberTableRow: VFC<Props> = ({ user, team }) => {
+export const TeamMemberTableRow: VFC<Props> = ({ user, currentUser, team }) => {
   const [isDeleteTeamMemberModal, setIsDeleteTeamMemberModal] = useState(false);
   const [isUpdateAdminUserOfTeamModal, setIsUpdateAdminUserOfTeamModal] = useState(false);
 
@@ -32,19 +33,21 @@ export const TeamMemberTableRow: VFC<Props> = ({ user, team }) => {
   return (
     <tr className="align-middle">
       <th scope="row">
-        <UserIcon attachmentId={user.iconImageId} userId={user._id} size={40} />
+        <UserIcon attachmentId={user.iconImageId} userId={user._id} size={40} isLink />
       </th>
       <td>{user.name}</td>
       <td>{team.adminUserId === user._id ? '管理者' : 'メンバー'}</td>
       <td className="text-end">
-        <Dropdown toggle={<Icon icon="THREE_DOTS_VERTICAL" size={20} />} tag="span">
-          {menuItems.map((menuItem, i) => (
-            <DropdownItem key={i} onClick={menuItem.onClick}>
-              {menuItem.icon}
-              <span className="ms-2">{menuItem.text}</span>
-            </DropdownItem>
-          ))}
-        </Dropdown>
+        {team.adminUserId === currentUser._id && team.adminUserId !== user._id && (
+          <Dropdown toggle={<Icon icon="THREE_DOTS_VERTICAL" size={20} />} tag="span">
+            {menuItems.map((menuItem, i) => (
+              <DropdownItem key={i} onClick={menuItem.onClick}>
+                {menuItem.icon}
+                <span className="ms-2">{menuItem.text}</span>
+              </DropdownItem>
+            ))}
+          </Dropdown>
+        )}
       </td>
       <DeleteTeamMemberModal
         isOpen={isDeleteTeamMemberModal}

--- a/src/components/domains/team/TeamMemberTableRow/index.tsx
+++ b/src/components/domains/team/TeamMemberTableRow/index.tsx
@@ -1,0 +1,1 @@
+export { TeamMemberTableRow } from './TeamMemberTableRow';


### PR DESCRIPTION
## 対象IssueのLink
close #659 

## 変更箇所
- メンバー設定画面で、チームメンバーを一覧表示する
- 三点メニューからプロダクトからユーザーの削除とプロダクトの管理者ユーザーを変更できるように実装



